### PR TITLE
remove unused code

### DIFF
--- a/example/exampleShapeBuilder.html
+++ b/example/exampleShapeBuilder.html
@@ -17,9 +17,6 @@
     function init() {
         const parent = document.getElementById("chart1-example")
 
-        const width = parent.offsetWidth
-        const height = parent.offsetHeight
-
         const drawEngine = new MapdDraw.ShapeBuilder(parent, {
           enableInteractions: true,
           cameraPosition: [0, 0]


### PR DESCRIPTION
`height` and `width` aren't used anywhere and it'd not clear that they are an example of anything, so I removed them to keep the example concise.