### PR TITLE
removed babel-lodash plugin

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,3 @@
 {
-  "plugins": ["lodash"],
   "presets": ["es2015", "stage-0"]
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "devDependencies": {
     "babel-core": "^6.10.4",
     "babel-loader": "^6.2.4",
-    "babel-plugin-lodash": "^3.1.2",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-stage-0": "^6.5.0",
     "babel-register": "^6.24.1",


### PR DESCRIPTION
Removes un-necessary `babel-plugin-lodash` that seem to be causing problems when running immerse unit tests locally.